### PR TITLE
Allow to be detected by gnome shell

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -21,25 +21,27 @@ slots:
     bus: session
     name: org.gnome.clocks
 
+plugs:
+  desktop:
+    desktop-file-ids:
+      - org.gnome.clocks
 apps:
   gnome-clocks:
     command: usr/bin/gnome-clocks
     extensions: [ gnome ]
     plugs:
       - audio-playback
-    desktop: usr/share/applications/org.gnome.clocks.desktop
 
 parts:
-
   buildenv:
     plugin: nil
     build-environment: &buildenv
       - PATH: $CRAFT_STAGE/usr/bin:$PATH
       - ACLOCAL_PATH: $CRAFT_STAGE/usr/share/aclocal
       - XDG_DATA_DIRS: $CRAFT_STAGE/usr/share:/usr/share:$XDG_DATA_DIRS
-      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/vala-0.56:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET:$LD_LIBRARY_PATH
-      - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders.cache
-      - PKG_CONFIG_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:$CRAFT_STAGE/usr/lib/pkgconfig:$CRAFT_STAGE/usr/share/pkgconfig:$PKG_CONFIG_PATH
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/vala-0.56:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$LD_LIBRARY_PATH
+      - GDK_PIXBUF_MODULE_FILE: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders.cache
+      - PKG_CONFIG_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig:$CRAFT_STAGE/usr/lib/pkgconfig:$CRAFT_STAGE/usr/share/pkgconfig:$PKG_CONFIG_PATH
 
   gnome-clocks:
     source: https://gitlab.gnome.org/GNOME/gnome-clocks.git
@@ -53,17 +55,16 @@ parts:
       - --buildtype=release
     build-packages:
       - libgnome-desktop-4-dev
-      - libgeocode-glib-dev
       - libgeoclue-2-dev
     build-environment: *buildenv
     stage-packages:
       - libgeoclue-2-0
-      - libgeocode-glib-2-0
     override-build: |
       craftctl default
       sed -i 's|Icon=org.gnome.clocks$|Icon=${SNAP}/meta/gui/org.gnome.clocks.svg|g' $CRAFT_PART_INSTALL/usr/share/applications/org.gnome.clocks.desktop
       mkdir -p $CRAFT_PART_INSTALL/meta/gui
       cp $CRAFT_PART_SRC/data/icons/hicolor/scalable/apps/org.gnome.clocks.svg $CRAFT_PART_INSTALL/meta/gui/
+      cp $CRAFT_PART_INSTALL/usr/share/applications/org.gnome.clocks.desktop $CRAFT_PART_INSTALL/meta/gui/
 
   cleanup:
     after: [ gnome-clocks ]
@@ -78,8 +79,8 @@ parts:
       rm -f usr/lib/*.la
       rm -f usr/lib/*/*.la
       rm -rf usr/include
-      rm -rf usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0
-      rm -rf usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig
+      rm -rf usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0
+      rm -rf usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig
 
       find . -type d -empty -delete
       for snap in "core24" "gtk-common-themes" "gnome-46-2404"; do


### PR DESCRIPTION
## Description

Gnome Shell expects an `org.gnome.clocks.desktop` file to detect Clocks. But until today, the snapped version created a `gnome-clocks_gnome-clocks.desktop` file. This patch uses the DESKTOP plug to define it.

It also fixes the TRIPLET environment variables and removes `libgeocode`, because it's already in gnome-46-2404.

## Type of change

Please check only the options that are relevant.

- [ ] General Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Removed gnome-clocks .deb package from the system. The clock drop-down window stopped showing the clocks I have defined.

Installed the `edge` gnome-clocks snap. The clock drop-down window still doesn't show my clocks, but I can launch the gnome-clocks application by searching it in the Activities view.

Installed this snap. The clock drop-down window shown again my defined clocks, and clicking on them opens the gnome-clocks application.

**Test Configuration**:

* OS (please include version): Ubuntu 25.04
* Any other relevant environment information: tested with stable channel snapd and snapcraft.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

Fix #5
